### PR TITLE
dx: added devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+# [Choice] Debian OS version: bullseye, buster
+ARG VARIANT=bullseye
+FROM --platform=linux/amd64 mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+ENV DENO_INSTALL=/deno
+ENV DENO_VERSION=v1.20.5
+
+RUN mkdir -p /deno \
+    && curl -fsSL https://deno.land/x/install/install.sh | sh -s ${DENO_VERSION} \
+    && chown -R vscode /deno
+
+ENV PATH=${DENO_INSTALL}/bin:${PATH} \
+    DENO_DIR=${DENO_INSTALL}/.cache/deno
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#    && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.205.1/containers/deno
+{
+  "name": "Ultra.js Quickstart",
+
+  "build": {
+    "dockerfile": "Dockerfile",
+    // Update 'VARIANT' to pick an Debian OS version: bullseye, buster
+    "args": {
+      "VARIANT": "bullseye"
+    }
+  },
+
+  // This will install the vscode-deno extension
+  "extensions": ["denoland.vscode-deno"],
+
+  "remoteUser": "vscode"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,12 @@
   "deno.importMap": "./importMap.json",
   "deno.suggest.imports.hosts": {
     "https://deno.land": false
+  },
+  "editor.defaultFormatter": "denoland.vscode-deno",
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
   }
 }


### PR DESCRIPTION
Always handy to have for those developers who use devcontainers in VSCode. Does require Docker to be installed on the system.